### PR TITLE
Initialized Route for removing users

### DIFF
--- a/models/party.js
+++ b/models/party.js
@@ -110,6 +110,39 @@ class Party {
     return partyPlayers;    
   }
 
+  static async handleModifyParty(partyId, body) {
+    const bodyProps = ["name", "dm", "searchParameters", "mode"]
+    bodyProps.forEach((item) => {
+      if(!body.hasOwnProperty(item)) {
+        throw new BadRequestError("Missing Properties")
+      }
+    })
+    const searchProps = ["experience", "type", "genre", "level"]
+    searchProps.forEach((item) => {
+      if(!body.searchParameters.hasOwnProperty(item)) {
+        throw new BadRequestError("Missing Search Parameters")
+      }
+    })
+    
+    const partyQuery = new Parse.Query("Party")
+    const party = await partyQuery.get(partyId)
+
+    party.set("name", body.name)
+    const userQuery = new Parse.Query("User");
+    const dm = await userQuery.get(body.dm);
+    if(!dm.get("enabled")) {
+      console.log("disabled user")
+      throw new BadRequestError("Attempting to modify party for disabled user")
+    }
+    if(dm.objectId !== party.dm) {
+      throw new BadRequestError("Only the DM can modify party settings")
+    }
+    party.set("searchParameters", body.searchParameters)
+    party.set("status", body.mode)
+    let result = await party.save()
+    return result.id;
+  }
+
   static async deleteParty(partyId, dm) {
     const partyQuery = new Parse.Query("Party")
     const party = await partyQuery.get(partyId)
@@ -127,6 +160,35 @@ class Party {
     })
     await partyDm.save({}, {useMasterKey: true});
     party.destroy();
+  }
+
+  static async partyRemove(dmId, userId, partyId) {
+    const Parties = Parse.Object.extend("Party")
+    const partyQuery = new Parse.Query(Parties)
+    const party = await partyQuery.get(partyId)
+
+    const playerQuery = new Parse.Query("User")
+    const player = await playerQuery.get(userId)
+    const dmQuery = new Parse.Query("User")
+    const dm = await dmQuery.get(dmId)
+    const partyDm = await party.get("dm")
+
+    if(dm.objectId !== partyDm.objectId) {
+      throw new BadRequestError("Only the DM can remove users from a party")
+    }
+
+    const notification = new Parse.Object("Notification");
+    notification.set("user", player)
+    notification.set("type", "remove")
+    notification.set("sourceUser", dm)
+    notification.save();
+
+    player.decrement("numParties", 1);
+    await player.save({}, {useMasterKey: true});
+
+    let playersRelation = party.relation('players')
+    playersRelation.remove(player)
+    party.save()
   }
 
 }

--- a/routes/party.js
+++ b/routes/party.js
@@ -80,6 +80,36 @@ router.post("/:partyId/reject/:userId", async (req, res, next) => {
     }
 })
 
+router.post("/:partyId/remove/:userId", async (req, res, next) => {
+  try {
+    const dmId = req.body.dm.objectId
+    const userId = req.params.userId
+    const partyId = req.params.partyId;
+    await Party.partyRemove(dmId, userId, partyId)
+    res.status(201).json({})
+  }
+  catch(err) {
+    console.log(err)
+    next(err)
+  }
+})
+
+router.post("/:partyId/modify", async (req, res, next) => {
+    try {
+        const body = req.body;
+        const partyId = req.params.partyId
+        const party = await Party.handleModifyParty(partyId, body)
+        if(party == null) {
+            throw new Error("Internal Server Error")
+        }
+        res.status(201).json({})
+    }
+    catch(err) {
+        console.log(err)
+        next(err)
+    }
+})
+
 router.post("/:partyId/delete", async (req, res, next) => {
     try {
         const partyId = req.params.partyId;

--- a/routes/user.js
+++ b/routes/user.js
@@ -76,18 +76,4 @@ router.post("/:userId/disable", async (req, res, next) => {
   }
 })
 
-router.post("/:partyId/remove/:userId", async (req, res, next) => {
-  try {
-    const dm = req.body.userId.objectId
-    const userId = req.params.userId
-    const partyId = req.params.partyId;
-    await User.partyRemove(dm, userId, partyId)
-    res.status(201).json({})
-  }
-  catch(err) {
-    console.log(err)
-    next(err)
-  }
-})
-
 module.exports = router;


### PR DESCRIPTION
## What
Initialized route to remove users

## Why
Provides more security than the old way--does checking to see if the request is made by the DM in the backend instead of the frontend to help prevent interference