### PR TITLE
Update: Enabled cursor-based pagination in handleSearchParty()

### DIFF
--- a/models/party.js
+++ b/models/party.js
@@ -53,13 +53,15 @@ class Party {
     return users;
   }
 
-  static async handleSearchParty(searchParameters, userId) {
+  static async handleSearchParty(searchParameters, userId, first, last) {
     const searchProps = ["experience", "type", "genre", "level"]
     searchProps.forEach((item) => {
       if(!searchParameters.hasOwnProperty(item)) {
         throw new BadRequestError("Missing Search Parameters")
       }
     })
+
+    const pageLimit = 2;
 
     const userQuery = new Parse.Query("User")
     const user = await userQuery.get(userId)
@@ -72,6 +74,10 @@ class Party {
     const dmQuery = new Parse.Query("Party");
     const findPlayerParties = new Parse.Query("Party")
     const playerQuery = new Parse.Query("Party")
+    const firstQuery = new Parse.Query("Party")
+    const lastQuery = new Parse.Query("Party")
+
+    var ascending = first===null ? false : true;
 
     experienceQuery.equalTo("searchParameters.experience", searchParameters.experience)
     if(searchParameters.type.substring(0, 3) !=="Any") {
@@ -88,15 +94,42 @@ class Party {
     findPlayerParties.equalTo("players", user)
     playerQuery.doesNotMatchKeyInQuery("objectId", "objectId", findPlayerParties)
 
-    const query =  Parse.Query.and(experienceQuery, typeQuery, genreQuery, levelQuery, statusQuery, dmQuery, playerQuery)
-    query.ascending("createdAt")
+    if(first!==null) {
+      const getFirstQuery = new Parse.Query("Party")
+      const firstParty = await getFirstQuery.get(first.objectId)
+      firstQuery.greaterThan("createdAt", firstParty.get("createdAt"))
+    }
+    else if(last!==null) {
+      const getLastQuery = new Parse.Query("Party")
+      const lastParty = await getLastQuery.get(last.objectId)
+      lastQuery.lessThan("createdAt", lastParty.createdAt)
+    }
+
+    const query =  Parse.Query.and(experienceQuery, typeQuery, genreQuery, levelQuery, statusQuery, dmQuery, playerQuery, firstQuery, lastQuery)
+    if(ascending) {
+      query.ascending("createdAt")
+    }
+    else {
+      query.descending("createdAt")
+    }
+    query.limit(pageLimit+1);
     const parties = await query.find();
 
     if(parties.length==0) {
       return null;
     }
+    var reachedEnd = false;
+    if(parties.length<=pageLimit) {
+      reachedEnd = true;
+    }
+    else {
+      parties.splice(pageLimit)
+    }
+    if(first!==null) {
+      parties.reverse();
+    }
 
-    return parties;
+    return {parties: parties, reachedEnd: reachedEnd};
   }
 
   static async getMembers(partyId) {

--- a/routes/party.js
+++ b/routes/party.js
@@ -31,9 +31,17 @@ router.get("/:partyId", async (req, res, next) => {
 router.post("/search", async (req, res, next) => {
     try {
         const searchParameters = req.body.searchParameters;
+        var first = null;
+        var last = null;
+        if(req.body.hasOwnProperty("first")) {
+            first = req.body.first
+        }
+        else if(req.body.hasOwnProperty("last")) {
+            last = req.body.last;
+        }
         const userId = req.body.user
-        const parties = await Party.handleSearchParty(searchParameters, userId)
-        res.status(201).json({ parties })
+        const response = await Party.handleSearchParty(searchParameters, userId, first, last)
+        res.status(201).json({ response })
     }
     catch(err) {
         console.log(err)


### PR DESCRIPTION
## What
Enabled cursor-based pagination in handleSearchParty()

## Why
Enables scalability: as more parties are created, this ensures that users aren't receiving too many parties (reduces load times). Instead, dynamically gets more parties as needed

## How
Cursor based: receives either a "first" or "last" from the frontend and uses that cursor to get the parties that are either before or after that party