### PR TITLE
Party ranking

### DIFF
--- a/models/party.js
+++ b/models/party.js
@@ -59,8 +59,6 @@ class Party {
   }
 
   static async handleSearchParty(searchParameters, userId, first, last) {
-    console.log('last: ', last);
-    console.log('first: ', first);
     
     const pageLimit = 2;
 
@@ -621,7 +619,6 @@ class Party {
       if(partiesObjects.length<=limit) {
         const restOfParties = await first35(null, limit - partiesObjects.length)
         reachedEnd = restOfParties.reachedEnd;
-        console.log('[...restOfParties.parties, ...partiesObjects]: ', [...restOfParties.parties, ...partiesObjects]);
         return {parties: [...restOfParties.parties, ...partiesObjects], reachedEnd: reachedEnd};
       }
       else {

--- a/models/party.js
+++ b/models/party.js
@@ -59,7 +59,9 @@ class Party {
   }
 
   static async handleSearchParty(searchParameters, userId, first, last) {
-
+    console.log('last: ', last);
+    console.log('first: ', first);
+    
     const pageLimit = 2;
 
     const userQuery = new Parse.Query("User")
@@ -73,7 +75,7 @@ class Party {
     const dmQuery = new Parse.Query("Party");
     const findPlayerParties = new Parse.Query("Party")
     const playerQuery = new Parse.Query("Party")
-    const pageQuery = new Parse.Query("Party")
+
     experienceQuery.equalTo("searchParameters.experience", searchParameters.experience)
     if(searchParameters.hasOwnProperty("type")) {
       typeQuery.equalTo("searchParameters.type", searchParameters.type)
@@ -390,13 +392,13 @@ class Party {
       return {parties: partiesObjects, reachedEnd: reachedEnd};
     }
 
-    const first100 = async (lastObjectId, limit) => {
+    const first100 = async (firstObjectId, limit) => {
       const pointerQuery = new Parse.Query("Party");
 
-      if(lastObjectId!==null) {
+      if(firstObjectId!==null) {
         const getLastQuery = new Parse.Query("Party")
-        const lastParty = await getLastQuery.get(lastObjectId)
-        pointerQuery.lessThan("createdAt", lastParty.get("createdAt"))
+        const lastParty = await getLastQuery.get(firstObjectId)
+        pointerQuery.greaterThan("createdAt", lastParty.get("createdAt"))
       } 
 
       const query = Parse.Query.and(experienceQuery, typeQuery, genreQuery, levelQuery, statusQuery, dmQuery, playerQuery, pointerQuery)
@@ -423,13 +425,13 @@ class Party {
       return {parties: partiesObjects, reachedEnd: reachedEnd};
     }
 
-    const first75 = async (lastObjectId, limit) => {
+    const first75 = async (firstObjectId, limit) => {
       const pointerQuery = new Parse.Query("Party");
 
-      if(lastObjectId!==null) {
+      if(firstObjectId!==null) {
         const getLastQuery = new Parse.Query("Party")
-        const lastParty = await getLastQuery.get(lastObjectId)
-        pointerQuery.lessThan("createdAt", lastParty.get("createdAt"))
+        const lastParty = await getLastQuery.get(firstObjectId)
+        pointerQuery.greaterThan("createdAt", lastParty.get("createdAt"))
       }
 
       const query = Parse.Query.and(experienceQuery, typeQuery, genreQuery, reverseLevelQuery, statusQuery, dmQuery, playerQuery, pointerQuery)
@@ -457,13 +459,13 @@ class Party {
       return {parties: partiesObjects, reachedEnd: reachedEnd};
     }
 
-    const first65 = async (lastObjectId, limit) => {
+    const first65 = async (firstObjectId, limit) => {
       const pointerQuery = new Parse.Query("Party");
 
-      if(lastObjectId!==null) {
+      if(firstObjectId!==null) {
         const getLastQuery = new Parse.Query("Party")
-        const lastParty = await getLastQuery.get(lastObjectId)
-        pointerQuery.lessThan("createdAt", lastParty.get("createdAt"))
+        const lastParty = await getLastQuery.get(firstObjectId)
+        pointerQuery.greaterThan("createdAt", lastParty.get("createdAt"))
       }
 
       const query = Parse.Query.and(experienceQuery, typeQuery, reverseGenreQuery, levelQuery, statusQuery, dmQuery, playerQuery, pointerQuery)
@@ -491,13 +493,13 @@ class Party {
       return {parties: partiesObjects, reachedEnd: reachedEnd};
     }
 
-    const first60 = async (lastObjectId, limit) => {
+    const first60 = async (firstObjectId, limit) => {
       const pointerQuery = new Parse.Query("Party");
 
-      if(lastObjectId!==null) {
+      if(firstObjectId!==null) {
         const getLastQuery = new Parse.Query("Party")
-        const lastParty = await getLastQuery.get(lastObjectId)
-        pointerQuery.lessThan("createdAt", lastParty.get("createdAt"))
+        const lastParty = await getLastQuery.get(firstObjectId)
+        pointerQuery.greaterThan("createdAt", lastParty.get("createdAt"))
       }
 
       const query = Parse.Query.and(experienceQuery, reverseTypeQuery, genreQuery, levelQuery, statusQuery, dmQuery, playerQuery, pointerQuery)
@@ -525,13 +527,13 @@ class Party {
       return {parties: partiesObjects, reachedEnd: reachedEnd};
     }
 
-    const first40 = async (lastObjectId, limit) => {
+    const first40 = async (firstObjectId, limit) => {
       const pointerQuery = new Parse.Query("Party");
 
-      if(lastObjectId!==null) {
+      if(firstObjectId!==null) {
         const getLastQuery = new Parse.Query("Party")
-        const lastParty = await getLastQuery.get(lastObjectId)
-        pointerQuery.lessThan("createdAt", lastParty.get("createdAt"))
+        const lastParty = await getLastQuery.get(firstObjectId)
+        pointerQuery.greaterThan("createdAt", lastParty.get("createdAt"))
       }
 
       const query = Parse.Query.and(experienceQuery, typeQuery, reverseGenreQuery, reverseLevelQuery, statusQuery, dmQuery, playerQuery, pointerQuery)
@@ -559,13 +561,13 @@ class Party {
       return {parties: partiesObjects, reachedEnd: reachedEnd};
     }
 
-    const first35 = async (lastObjectId, limit) => {
+    const first35 = async (firstObjectId, limit) => {
       const pointerQuery = new Parse.Query("Party");
 
-      if(lastObjectId!==null) {
+      if(firstObjectId!==null) {
         const getLastQuery = new Parse.Query("Party")
-        const lastParty = await getLastQuery.get(lastObjectId)
-        pointerQuery.lessThan("createdAt", lastParty.get("createdAt"))
+        const lastParty = await getLastQuery.get(firstObjectId)
+        pointerQuery.greaterThan("createdAt", lastParty.get("createdAt"))
       }
 
       const query = Parse.Query.and(experienceQuery, reverseTypeQuery, genreQuery, reverseLevelQuery, statusQuery, dmQuery, playerQuery, pointerQuery)
@@ -593,13 +595,13 @@ class Party {
       return {parties: partiesObjects, reachedEnd: reachedEnd};
     }
 
-    const first25 = async (lastObjectId, limit) => {
+    const first25 = async (firstObjectId, limit) => {
       const pointerQuery = new Parse.Query("Party");
 
-      if(lastObjectId!==null) {
+      if(firstObjectId!==null) {
         const getLastQuery = new Parse.Query("Party")
-        const lastParty = await getLastQuery.get(lastObjectId)
-        pointerQuery.lessThan("createdAt", lastParty.get("createdAt"))
+        const lastParty = await getLastQuery.get(firstObjectId)
+        pointerQuery.greaterThan("createdAt", lastParty.get("createdAt"))
       }
 
       const query = Parse.Query.and(experienceQuery, reverseTypeQuery, reverseGenreQuery, levelQuery, statusQuery, dmQuery, playerQuery, pointerQuery)
@@ -619,6 +621,7 @@ class Party {
       if(partiesObjects.length<=limit) {
         const restOfParties = await first35(null, limit - partiesObjects.length)
         reachedEnd = restOfParties.reachedEnd;
+        console.log('[...restOfParties.parties, ...partiesObjects]: ', [...restOfParties.parties, ...partiesObjects]);
         return {parties: [...restOfParties.parties, ...partiesObjects], reachedEnd: reachedEnd};
       }
       else {
@@ -627,13 +630,13 @@ class Party {
       return {parties: partiesObjects, reachedEnd: reachedEnd};
     }
 
-    const first0 = async (lastObjectId, limit) => {
+    const first0 = async (firstObjectId, limit) => {
       const pointerQuery = new Parse.Query("Party");
 
-      if(lastObjectId!==null) {
+      if(firstObjectId!==null) {
         const getLastQuery = new Parse.Query("Party")
-        const lastParty = await getLastQuery.get(lastObjectId)
-        pointerQuery.lessThan("createdAt", lastParty.get("createdAt"))
+        const lastParty = await getLastQuery.get(firstObjectId)
+        pointerQuery.greaterThan("createdAt", lastParty.get("createdAt"))
       }
 
       const query = Parse.Query.and(experienceQuery, reverseTypeQuery, reverseGenreQuery, reverseLevelQuery, statusQuery, dmQuery, playerQuery, pointerQuery)

--- a/models/party.js
+++ b/models/party.js
@@ -74,9 +74,6 @@ class Party {
     const findPlayerParties = new Parse.Query("Party")
     const playerQuery = new Parse.Query("Party")
     const pageQuery = new Parse.Query("Party")
-
-    var ascending = first===null ? false : true;
-
     experienceQuery.equalTo("searchParameters.experience", searchParameters.experience)
     if(searchParameters.hasOwnProperty("type")) {
       typeQuery.equalTo("searchParameters.type", searchParameters.type)
@@ -91,6 +88,349 @@ class Party {
     dmQuery.notEqualTo("dm", { '__type': 'Pointer', 'className': '_User', 'objectId': userId })
     findPlayerParties.equalTo("players", user)
     playerQuery.doesNotMatchKeyInQuery("objectId", "objectId", findPlayerParties)
+
+    const reverseTypeQuery = new Parse.Query("Party")
+    reverseTypeQuery.doesNotMatchKeyInQuery("objectId", "objectId", typeQuery)
+    const reverseGenreQuery = new Parse.Query("Party")
+    reverseGenreQuery.doesNotMatchKeyInQuery("objectId", "objectId", genreQuery)
+    const reverseLevelQuery = new Parse.Query("Party")
+    reverseLevelQuery.doesNotMatchKeyInQuery("objectId", "objectId", levelQuery)
+
+    const firstRequest = async () => {
+
+      const query = Parse.Query.and(experienceQuery, typeQuery, genreQuery, levelQuery, statusQuery, dmQuery, playerQuery)
+      query.descending("createdAt")
+      query.limit(pageLimit+1);
+      const parties = await query.find();
+
+      const partiesObjects = parties.map(item => {
+        return item.toJSON();
+      })
+
+      var reachedEnd = false;
+      partiesObjects.forEach((item) => {
+        item.relevance = 100
+      })
+      if(partiesObjects.length<=pageLimit) {
+        const restOfParties = await last75(null, pageLimit - partiesObjects.length)
+        reachedEnd = restOfParties.reachedEnd;
+        return {parties: [...partiesObjects, ...restOfParties.parties], reachedEnd: reachedEnd};
+      }
+      else {
+        partiesObjects.splice(pageLimit)
+      }
+
+      if(first!==null) {
+        partiesObjects.reverse();
+      }
+
+      return {parties: partiesObjects, reachedEnd: reachedEnd};
+    }
+
+    const last100 = async (lastObjectId, limit) => {
+      const pointerQuery = new Parse.Query("Party");
+
+      if(lastObjectId!==null) {
+        const getLastQuery = new Parse.Query("Party")
+        const lastParty = await getLastQuery.get(lastObjectId)
+        pointerQuery.lessThan("createdAt", lastParty.get("createdAt"))
+      } 
+
+      const query = Parse.Query.and(experienceQuery, typeQuery, genreQuery, levelQuery, statusQuery, dmQuery, playerQuery, pointerQuery)
+      query.descending("createdAt")
+      query.limit(limit+1);
+      const parties = await query.find();
+
+      const partiesObjects = parties.map(item => {
+        return item.toJSON();
+      })
+
+      var reachedEnd = false;
+      partiesObjects.forEach((item) => {
+        item.relevance = 100
+      })
+      if(partiesObjects.length<=limit) {
+        const restOfParties = await last75(null, limit - partiesObjects.length)
+        reachedEnd = restOfParties.reachedEnd;
+        return {parties: [...partiesObjects, ...restOfParties.parties], reachedEnd: reachedEnd};
+      }
+      else {
+        partiesObjects.splice(limit)
+      }
+      return {parties: partiesObjects, reachedEnd: reachedEnd};
+    }
+
+    const last75 = async (lastObjectId, limit) => {
+      const pointerQuery = new Parse.Query("Party");
+
+      if(lastObjectId!==null) {
+        const getLastQuery = new Parse.Query("Party")
+        const lastParty = await getLastQuery.get(lastObjectId)
+        pointerQuery.lessThan("createdAt", lastParty.get("createdAt"))
+      }
+
+      const query = Parse.Query.and(experienceQuery, typeQuery, genreQuery, reverseLevelQuery, statusQuery, dmQuery, playerQuery, pointerQuery)
+      query.descending("createdAt")
+      query.limit(limit+1);
+      const parties = await query.find();
+
+      const partiesObjects = parties.map(item => {
+        return item.toJSON();
+      })
+
+      var reachedEnd = false;
+      partiesObjects.forEach((item) => {
+        item.relevance = 75
+      })
+      if(partiesObjects.length<=limit) {
+        const restOfParties = await last65(null, limit - partiesObjects.length)
+        reachedEnd = restOfParties.reachedEnd;
+        return {parties: [...partiesObjects, ...restOfParties.parties], reachedEnd: reachedEnd};
+      }
+      else {
+        partiesObjects.splice(limit)
+      }
+      return {parties: partiesObjects, reachedEnd: reachedEnd};
+    }
+
+    const last65 = async (lastObjectId, limit) => {
+      const pointerQuery = new Parse.Query("Party");
+
+      if(lastObjectId!==null) {
+        const getLastQuery = new Parse.Query("Party")
+        const lastParty = await getLastQuery.get(lastObjectId)
+        pointerQuery.lessThan("createdAt", lastParty.get("createdAt"))
+      }
+
+      const query = Parse.Query.and(experienceQuery, typeQuery, reverseGenreQuery, levelQuery, statusQuery, dmQuery, playerQuery, pointerQuery)
+      query.descending("createdAt")
+      query.limit(limit+1);
+      const parties = await query.find();
+
+      const partiesObjects = parties.map(item => {
+        return item.toJSON();
+      })
+
+      var reachedEnd = false;
+      partiesObjects.forEach((item) => {
+        item.relevance = 65
+      })
+      if(partiesObjects.length<=limit) {
+        const restOfParties = await last60(null, limit - partiesObjects.length)
+        reachedEnd = restOfParties.reachedEnd;
+        return {parties: [...partiesObjects, ...restOfParties.parties], reachedEnd: reachedEnd};
+      }
+      else {
+        partiesObjects.splice(limit)
+      }
+      return {parties: partiesObjects, reachedEnd: reachedEnd};
+    }
+
+    const last60 = async (lastObjectId, limit) => {
+      const pointerQuery = new Parse.Query("Party");
+
+      if(lastObjectId!==null) {
+        const getLastQuery = new Parse.Query("Party")
+        const lastParty = await getLastQuery.get(lastObjectId)
+        pointerQuery.lessThan("createdAt", lastParty.get("createdAt"))
+      }
+
+      const query = Parse.Query.and(experienceQuery, reverseTypeQuery, genreQuery, levelQuery, statusQuery, dmQuery, playerQuery, pointerQuery)
+      query.descending("createdAt")
+      query.limit(limit+1);
+      const parties = await query.find();
+
+      const partiesObjects = parties.map(item => {
+        return item.toJSON();
+      })
+
+      var reachedEnd = false;
+      partiesObjects.forEach((item) => {
+        item.relevance = 60
+      })
+      if(partiesObjects.length<=limit) {
+        const restOfParties = await last40(null, limit - partiesObjects.length)
+        reachedEnd = restOfParties.reachedEnd;
+        return {parties: [...partiesObjects, ...restOfParties.parties], reachedEnd: reachedEnd};
+      }
+      else {
+        partiesObjects.splice(limit)
+      }
+      return {parties: partiesObjects, reachedEnd: reachedEnd};
+    }
+
+    const last40 = async (lastObjectId, limit) => {
+      const pointerQuery = new Parse.Query("Party");
+
+      if(lastObjectId!==null) {
+        const getLastQuery = new Parse.Query("Party")
+        const lastParty = await getLastQuery.get(lastObjectId)
+        pointerQuery.lessThan("createdAt", lastParty.get("createdAt"))
+      }
+
+      const query = Parse.Query.and(experienceQuery, typeQuery, reverseGenreQuery, reverseLevelQuery, statusQuery, dmQuery, playerQuery, pointerQuery)
+      query.descending("createdAt")
+      query.limit(limit+1);
+      const parties = await query.find();
+
+      const partiesObjects = parties.map(item => {
+        return item.toJSON();
+      })
+
+      var reachedEnd = false;
+      partiesObjects.forEach((item) => {
+        item.relevance = 40
+      })
+      if(partiesObjects.length<=limit) {
+        const restOfParties = await last35(null, limit - partiesObjects.length)
+        reachedEnd = restOfParties.reachedEnd;
+        return {parties: [...partiesObjects, ...restOfParties.parties], reachedEnd: reachedEnd};
+      }
+      else {
+        partiesObjects.splice(limit)
+      }
+      return {parties: partiesObjects, reachedEnd: reachedEnd};
+    }
+
+    const last35 = async (lastObjectId, limit) => {
+      const pointerQuery = new Parse.Query("Party");
+
+      if(lastObjectId!==null) {
+        const getLastQuery = new Parse.Query("Party")
+        const lastParty = await getLastQuery.get(lastObjectId)
+        pointerQuery.lessThan("createdAt", lastParty.get("createdAt"))
+      }
+
+      const query = Parse.Query.and(experienceQuery, reverseTypeQuery, genreQuery, reverseLevelQuery, statusQuery, dmQuery, playerQuery, pointerQuery)
+      query.descending("createdAt")
+      query.limit(limit+1);
+      const parties = await query.find();
+
+      const partiesObjects = parties.map(item => {
+        return item.toJSON();
+      })
+
+      var reachedEnd = false;
+      partiesObjects.forEach((item) => {
+        item.relevance = 35
+      })
+      if(partiesObjects.length<=limit) {
+        const restOfParties = await last25(null, limit - partiesObjects.length)
+        reachedEnd = restOfParties.reachedEnd;
+        return {parties: [...partiesObjects, ...restOfParties.parties], reachedEnd: reachedEnd};
+      }
+      else {
+        partiesObjects.splice(limit)
+      }
+      return {parties: partiesObjects, reachedEnd: reachedEnd};
+    }
+
+    const last25 = async (lastObjectId, limit) => {
+      const pointerQuery = new Parse.Query("Party");
+
+      if(lastObjectId!==null) {
+        const getLastQuery = new Parse.Query("Party")
+        const lastParty = await getLastQuery.get(lastObjectId)
+        pointerQuery.lessThan("createdAt", lastParty.get("createdAt"))
+      }
+
+      const query = Parse.Query.and(experienceQuery, reverseTypeQuery, reverseGenreQuery, levelQuery, statusQuery, dmQuery, playerQuery, pointerQuery)
+      query.descending("createdAt")
+      query.limit(limit+1);
+      const parties = await query.find();
+
+      const partiesObjects = parties.map(item => {
+        return item.toJSON();
+      })
+
+      var reachedEnd = false;
+      partiesObjects.forEach((item) => {
+        item.relevance = 25
+      })
+      if(partiesObjects.length<=limit) {
+        const restOfParties = await last0(null, limit - partiesObjects.length)
+        reachedEnd = restOfParties.reachedEnd;
+        return {parties: [...partiesObjects, ...restOfParties.parties], reachedEnd: reachedEnd};
+      }
+      else {
+        partiesObjects.splice(limit)
+      }
+      return {parties: partiesObjects, reachedEnd: reachedEnd};
+    }
+
+    const last0 = async (lastObjectId, limit) => {
+      const pointerQuery = new Parse.Query("Party");
+
+      if(lastObjectId!==null) {
+        const getLastQuery = new Parse.Query("Party")
+        const lastParty = await getLastQuery.get(lastObjectId)
+        pointerQuery.lessThan("createdAt", lastParty.get("createdAt"))
+      }
+
+      const query = Parse.Query.and(experienceQuery, reverseTypeQuery, reverseGenreQuery, reverseLevelQuery, statusQuery, dmQuery, playerQuery, pointerQuery)
+      query.descending("createdAt")
+      query.limit(limit+1);
+      const parties = await query.find();
+
+      const partiesObjects = parties.map(item => {
+        return item.toJSON();
+      })
+
+      var reachedEnd = false;
+      partiesObjects.forEach((item) => {
+        item.relevance = 0
+      })
+      if(partiesObjects.length<=limit) {
+        reachedEnd = true;
+        return {parties: partiesObjects, reachedEnd: reachedEnd};
+      }
+      else {
+        partiesObjects.splice(limit)
+      }
+      return {parties: partiesObjects, reachedEnd: reachedEnd};
+    }
+
+
+    
+    if(first!==null) {
+      if(first.relevance === 100)
+        return await first100(pageLimit);
+      if(first.relevance === 75)
+        return await first75(5);
+      if(first.relevance === 65)
+        return await first65(5);
+      if(first.relevance === 60)
+        return await first60(5);
+      if(first.relevance === 45)
+        return await first40(5);
+      if(first.relevance === 35)
+        return await first35(5);
+      if(first.relevance === 25)
+        return await first25(5)
+      if(first.relevance === 0) {
+        return await first0(5);
+      }
+    }
+    if(last!==null) {
+      if(last.relevance === 100)
+        return await last100(last.objectId, pageLimit);
+      if(last.relevance === 75)
+        return await last75(last.objectId, pageLimit);
+      if(last.relevance === 65)
+        return await last65(last.objectId, pageLimit);
+      if(last.relevance === 60)
+        return await last60(last.objectId, pageLimit);
+      if(last.relevance === 40)
+        return await last40(last.objectId, pageLimit);
+      if(last.relevance === 35)
+        return await last35(last.objectId, pageLimit);
+      if(last.relevance === 25)
+        return await last25(last.objectId, pageLimit)
+      if(last.relevance === 0) 
+        return await last0(last.objectId, pageLimit);
+      
+    }
+    return await firstRequest()
 
     if(first!==null) {
       const getFirstQuery = new Parse.Query("Party")
@@ -113,21 +453,40 @@ class Party {
     query.limit(pageLimit+1);
     const parties = await query.find();
 
-    if(parties.length==0) {
+    const partiesObjects = parties.map(item => {
+      return item.toJSON();
+    })
+
+    if(partiesObjects.length==0) {
       return null;
     }
     var reachedEnd = false;
-    if(parties.length<=pageLimit) {
+    if(partiesObjects.length<=pageLimit) {
       reachedEnd = true;
+      if(first!==null) {
+        partiesObjects.reverse();
+      }
+      partiesObjects.forEach((item) => {
+        item.relevance = 100
+      })
+      return {parties: partiesObjects, reachedEnd: reachedEnd};
     }
     else {
-      parties.splice(pageLimit)
-    }
-    if(first!==null) {
-      parties.reverse();
+      partiesObjects.splice(pageLimit)
     }
 
-    return {parties: parties, reachedEnd: reachedEnd};
+    if(first!==null) {
+      partiesObjects.reverse();
+    }
+    partiesObjects.forEach((item) => {
+      item.relevance = 100
+    })
+    return {parties: partiesObjects, reachedEnd: reachedEnd};
+    
+
+    
+
+    
   }
 
   static async getMembers(partyId) {

--- a/models/party.js
+++ b/models/party.js
@@ -390,27 +390,277 @@ class Party {
       return {parties: partiesObjects, reachedEnd: reachedEnd};
     }
 
+    const first100 = async (lastObjectId, limit) => {
+      const pointerQuery = new Parse.Query("Party");
 
-    
-    if(first!==null) {
-      if(first.relevance === 100)
-        return await first100(pageLimit);
-      if(first.relevance === 75)
-        return await first75(5);
-      if(first.relevance === 65)
-        return await first65(5);
-      if(first.relevance === 60)
-        return await first60(5);
-      if(first.relevance === 45)
-        return await first40(5);
-      if(first.relevance === 35)
-        return await first35(5);
-      if(first.relevance === 25)
-        return await first25(5)
-      if(first.relevance === 0) {
-        return await first0(5);
+      if(lastObjectId!==null) {
+        const getLastQuery = new Parse.Query("Party")
+        const lastParty = await getLastQuery.get(lastObjectId)
+        pointerQuery.lessThan("createdAt", lastParty.get("createdAt"))
+      } 
+
+      const query = Parse.Query.and(experienceQuery, typeQuery, genreQuery, levelQuery, statusQuery, dmQuery, playerQuery, pointerQuery)
+      query.ascending("createdAt")
+      query.limit(limit+1);
+      const parties = await query.find();
+
+      const partiesObjects = parties.map(item => {
+        return item.toJSON();
+      })
+
+      var reachedEnd = false;
+      partiesObjects.forEach((item) => {
+        item.relevance = 100
+      })
+      partiesObjects.reverse();
+      if(partiesObjects.length<=limit) {
+        reachedEnd = true;
+        return {parties: partiesObjects, reachedEnd: reachedEnd};
       }
+      else {
+        partiesObjects.splice(limit)
+      }
+      return {parties: partiesObjects, reachedEnd: reachedEnd};
     }
+
+    const first75 = async (lastObjectId, limit) => {
+      const pointerQuery = new Parse.Query("Party");
+
+      if(lastObjectId!==null) {
+        const getLastQuery = new Parse.Query("Party")
+        const lastParty = await getLastQuery.get(lastObjectId)
+        pointerQuery.lessThan("createdAt", lastParty.get("createdAt"))
+      }
+
+      const query = Parse.Query.and(experienceQuery, typeQuery, genreQuery, reverseLevelQuery, statusQuery, dmQuery, playerQuery, pointerQuery)
+      query.ascending("createdAt")
+      query.limit(limit+1);
+      const parties = await query.find();
+
+      const partiesObjects = parties.map(item => {
+        return item.toJSON();
+      })
+
+      var reachedEnd = false;
+      partiesObjects.forEach((item) => {
+        item.relevance = 75
+      })
+      partiesObjects.reverse();
+      if(partiesObjects.length<=limit) {
+        const restOfParties = await first100(null, limit - partiesObjects.length)
+        reachedEnd = restOfParties.reachedEnd;
+        return {parties: [...restOfParties.parties, ...partiesObjects], reachedEnd: reachedEnd};
+      }
+      else {
+        partiesObjects.splice(limit)
+      }
+      return {parties: partiesObjects, reachedEnd: reachedEnd};
+    }
+
+    const first65 = async (lastObjectId, limit) => {
+      const pointerQuery = new Parse.Query("Party");
+
+      if(lastObjectId!==null) {
+        const getLastQuery = new Parse.Query("Party")
+        const lastParty = await getLastQuery.get(lastObjectId)
+        pointerQuery.lessThan("createdAt", lastParty.get("createdAt"))
+      }
+
+      const query = Parse.Query.and(experienceQuery, typeQuery, reverseGenreQuery, levelQuery, statusQuery, dmQuery, playerQuery, pointerQuery)
+      query.ascending("createdAt")
+      query.limit(limit+1);
+      const parties = await query.find();
+
+      const partiesObjects = parties.map(item => {
+        return item.toJSON();
+      })
+
+      var reachedEnd = false;
+      partiesObjects.forEach((item) => {
+        item.relevance = 65
+      })
+      partiesObjects.reverse();
+      if(partiesObjects.length<=limit) {
+        const restOfParties = await first75(null, limit - partiesObjects.length)
+        reachedEnd = restOfParties.reachedEnd;
+        return {parties: [...restOfParties.parties, ...partiesObjects], reachedEnd: reachedEnd};
+      }
+      else {
+        partiesObjects.splice(limit)
+      }
+      return {parties: partiesObjects, reachedEnd: reachedEnd};
+    }
+
+    const first60 = async (lastObjectId, limit) => {
+      const pointerQuery = new Parse.Query("Party");
+
+      if(lastObjectId!==null) {
+        const getLastQuery = new Parse.Query("Party")
+        const lastParty = await getLastQuery.get(lastObjectId)
+        pointerQuery.lessThan("createdAt", lastParty.get("createdAt"))
+      }
+
+      const query = Parse.Query.and(experienceQuery, reverseTypeQuery, genreQuery, levelQuery, statusQuery, dmQuery, playerQuery, pointerQuery)
+      query.ascending("createdAt")
+      query.limit(limit+1);
+      const parties = await query.find();
+
+      const partiesObjects = parties.map(item => {
+        return item.toJSON();
+      })
+
+      var reachedEnd = false;
+      partiesObjects.forEach((item) => {
+        item.relevance = 60
+      })
+      partiesObjects.reverse();
+      if(partiesObjects.length<=limit) {
+        const restOfParties = await first65(null, limit - partiesObjects.length)
+        reachedEnd = restOfParties.reachedEnd;
+        return {parties: [...restOfParties.parties, ...partiesObjects], reachedEnd: reachedEnd};
+      }
+      else {
+        partiesObjects.splice(limit)
+      }
+      return {parties: partiesObjects, reachedEnd: reachedEnd};
+    }
+
+    const first40 = async (lastObjectId, limit) => {
+      const pointerQuery = new Parse.Query("Party");
+
+      if(lastObjectId!==null) {
+        const getLastQuery = new Parse.Query("Party")
+        const lastParty = await getLastQuery.get(lastObjectId)
+        pointerQuery.lessThan("createdAt", lastParty.get("createdAt"))
+      }
+
+      const query = Parse.Query.and(experienceQuery, typeQuery, reverseGenreQuery, reverseLevelQuery, statusQuery, dmQuery, playerQuery, pointerQuery)
+      query.ascending("createdAt")
+      query.limit(limit+1);
+      const parties = await query.find();
+
+      const partiesObjects = parties.map(item => {
+        return item.toJSON();
+      })
+
+      var reachedEnd = false;
+      partiesObjects.forEach((item) => {
+        item.relevance = 40
+      })
+      partiesObjects.reverse();
+      if(partiesObjects.length<=limit) {
+        const restOfParties = await first60(null, limit - partiesObjects.length)
+        reachedEnd = restOfParties.reachedEnd;
+        return {parties: [...restOfParties.parties, ...partiesObjects], reachedEnd: reachedEnd};
+      }
+      else {
+        partiesObjects.splice(limit)
+      }
+      return {parties: partiesObjects, reachedEnd: reachedEnd};
+    }
+
+    const first35 = async (lastObjectId, limit) => {
+      const pointerQuery = new Parse.Query("Party");
+
+      if(lastObjectId!==null) {
+        const getLastQuery = new Parse.Query("Party")
+        const lastParty = await getLastQuery.get(lastObjectId)
+        pointerQuery.lessThan("createdAt", lastParty.get("createdAt"))
+      }
+
+      const query = Parse.Query.and(experienceQuery, reverseTypeQuery, genreQuery, reverseLevelQuery, statusQuery, dmQuery, playerQuery, pointerQuery)
+      query.ascending("createdAt")
+      query.limit(limit+1);
+      const parties = await query.find();
+
+      const partiesObjects = parties.map(item => {
+        return item.toJSON();
+      })
+
+      var reachedEnd = false;
+      partiesObjects.forEach((item) => {
+        item.relevance = 35
+      })
+      partiesObjects.reverse();
+      if(partiesObjects.length<=limit) {
+        const restOfParties = await first40(null, limit - partiesObjects.length)
+        reachedEnd = restOfParties.reachedEnd;
+        return {parties: [...restOfParties.parties, ...partiesObjects], reachedEnd: reachedEnd};
+      }
+      else {
+        partiesObjects.splice(limit)
+      }
+      return {parties: partiesObjects, reachedEnd: reachedEnd};
+    }
+
+    const first25 = async (lastObjectId, limit) => {
+      const pointerQuery = new Parse.Query("Party");
+
+      if(lastObjectId!==null) {
+        const getLastQuery = new Parse.Query("Party")
+        const lastParty = await getLastQuery.get(lastObjectId)
+        pointerQuery.lessThan("createdAt", lastParty.get("createdAt"))
+      }
+
+      const query = Parse.Query.and(experienceQuery, reverseTypeQuery, reverseGenreQuery, levelQuery, statusQuery, dmQuery, playerQuery, pointerQuery)
+      query.ascending("createdAt")
+      query.limit(limit+1);
+      const parties = await query.find();
+
+      const partiesObjects = parties.map(item => {
+        return item.toJSON();
+      })
+
+      var reachedEnd = false;
+      partiesObjects.forEach((item) => {
+        item.relevance = 25
+      })
+      partiesObjects.reverse();
+      if(partiesObjects.length<=limit) {
+        const restOfParties = await first35(null, limit - partiesObjects.length)
+        reachedEnd = restOfParties.reachedEnd;
+        return {parties: [...restOfParties.parties, ...partiesObjects], reachedEnd: reachedEnd};
+      }
+      else {
+        partiesObjects.splice(limit)
+      }
+      return {parties: partiesObjects, reachedEnd: reachedEnd};
+    }
+
+    const first0 = async (lastObjectId, limit) => {
+      const pointerQuery = new Parse.Query("Party");
+
+      if(lastObjectId!==null) {
+        const getLastQuery = new Parse.Query("Party")
+        const lastParty = await getLastQuery.get(lastObjectId)
+        pointerQuery.lessThan("createdAt", lastParty.get("createdAt"))
+      }
+
+      const query = Parse.Query.and(experienceQuery, reverseTypeQuery, reverseGenreQuery, reverseLevelQuery, statusQuery, dmQuery, playerQuery, pointerQuery)
+      query.ascending("createdAt")
+      query.limit(limit+1);
+      const parties = await query.find();
+
+      const partiesObjects = parties.map(item => {
+        return item.toJSON();
+      })
+
+      var reachedEnd = false;
+      partiesObjects.forEach((item) => {
+        item.relevance = 0
+      })
+      partiesObjects.reverse();
+      if(partiesObjects.length<=limit) {
+        const restOfParties = await first25(null, limit - partiesObjects.length)
+        reachedEnd = restOfParties.reachedEnd;
+        return {parties: [...restOfParties.parties, ...partiesObjects], reachedEnd: reachedEnd};
+      }
+      else {
+        partiesObjects.splice(limit)
+      }
+      return {parties: partiesObjects, reachedEnd: reachedEnd};
+    }
+
     if(last!==null) {
       if(last.relevance === 100)
         return await last100(last.objectId, pageLimit);
@@ -430,58 +680,27 @@ class Party {
         return await last0(last.objectId, pageLimit);
       
     }
+    if(first!==null) {
+      if(first.relevance === 100)
+        return await first100(first.objectId, pageLimit);
+      if(first.relevance === 75)
+        return await first75(first.objectId, pageLimit);
+      if(first.relevance === 65)
+        return await first65(first.objectId, pageLimit);
+      if(first.relevance === 60)
+        return await first60(first.objectId, pageLimit);
+      if(first.relevance === 45)
+        return await first40(first.objectId, pageLimit);
+      if(first.relevance === 35)
+        return await first35(first.objectId, pageLimit);
+      if(first.relevance === 25)
+        return await first25(first.objectId, pageLimit)
+      if(first.relevance === 0) {
+        return await first0(first.objectId, pageLimit);
+      }
+    }
     return await firstRequest()
 
-    if(first!==null) {
-      const getFirstQuery = new Parse.Query("Party")
-      const firstParty = await getFirstQuery.get(first.objectId)
-      pageQuery.greaterThan("createdAt", firstParty.get("createdAt"))
-    }
-    else if(last!==null) {
-      const getLastQuery = new Parse.Query("Party")
-      const lastParty = await getLastQuery.get(last.objectId)
-      pageQuery.lessThan("createdAt", lastParty.get("createdAt"))
-    }
-
-    const query = Parse.Query.and(experienceQuery, typeQuery, genreQuery, levelQuery, statusQuery, dmQuery, playerQuery, pageQuery)
-    if(ascending) {
-      query.ascending("createdAt")
-    }
-    else {
-      query.descending("createdAt")
-    }
-    query.limit(pageLimit+1);
-    const parties = await query.find();
-
-    const partiesObjects = parties.map(item => {
-      return item.toJSON();
-    })
-
-    if(partiesObjects.length==0) {
-      return null;
-    }
-    var reachedEnd = false;
-    if(partiesObjects.length<=pageLimit) {
-      reachedEnd = true;
-      if(first!==null) {
-        partiesObjects.reverse();
-      }
-      partiesObjects.forEach((item) => {
-        item.relevance = 100
-      })
-      return {parties: partiesObjects, reachedEnd: reachedEnd};
-    }
-    else {
-      partiesObjects.splice(pageLimit)
-    }
-
-    if(first!==null) {
-      partiesObjects.reverse();
-    }
-    partiesObjects.forEach((item) => {
-      item.relevance = 100
-    })
-    return {parties: partiesObjects, reachedEnd: reachedEnd};
     
 
     

--- a/routes/party.js
+++ b/routes/party.js
@@ -31,6 +31,7 @@ router.get("/:partyId", async (req, res, next) => {
 router.post("/search", async (req, res, next) => {
     try {
         const searchParameters = req.body.searchParameters;
+        const partyName = req.body.name
         var first = null;
         var last = null;
         if(req.body.hasOwnProperty("first")) {
@@ -40,7 +41,12 @@ router.post("/search", async (req, res, next) => {
             last = req.body.last;
         }
         const userId = req.body.user
-        const response = await Party.handleSearchParty(searchParameters, userId, first, last)
+        let response;
+        if(searchParameters)
+            response = await Party.handleSearchParty(searchParameters, userId, first, last)
+        else {
+            response = await Party.handleSearchPartyByName(partyName, userId, first, last)
+        }
         res.status(201).json({ response })
     }
     catch(err) {


### PR DESCRIPTION
## What
Added ranking system (that works with pagination to ensure you're not querying too many results) to rank parties based on relevance

## Why
Players can now see more party options: they may be interested in parties that don't meet all of their selected criteria, so this update gives users more results. Results are ordered by relevance, so results that meet all criteria are displayed first, but this update allows users to see more search options.

## How
If the backend server runs out of results at the current relevance level, it queries at the next relevance level, continuing until it runs out of results at relevance 0.